### PR TITLE
New option which allows to detect props' functions and their names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,9 @@ function serializeItem (item, options, delimit=true) {
       return match.slice(1, match.length - 1);
     });
   } else if (typeof item === 'function') {
-    result = '...';
+    result = options.detectFunctions ?
+      item.name && (item.name !== options.key) ? item.name : item.toString() :
+      '...';
   }
   return result;
 }
@@ -67,7 +69,8 @@ function jsxToString (component, options) {
       component.type,
     ignoreProps: [],
     keyValueOverride: {},
-    spacing: 0
+    spacing: 0,
+    detectFunctions: false
   };
 
   let opts = {...baseOpts, ...options};
@@ -88,7 +91,7 @@ function jsxToString (component, options) {
         opts.ignoreProps.indexOf(key) === -1)
     }).map(key => {
       let value = opts.keyValueOverride[key] ||
-        serializeItem(component.props[key], opts);
+        serializeItem(component.props[key], {...opts, key});
       if (typeof value !== 'string' || value[0] !== "'") {
         value = `{${value}}`;
       }

--- a/test/index.js
+++ b/test/index.js
@@ -105,6 +105,22 @@ test('test a react component with custom name function', function(t) {
   t.equal(output, '<Basic test1={_testCallBack1}\n  test2={_testCallBack2} />');
 });
 
+test('test a react component with autodetection of the functions names', function(t) {
+  t.plan(1);
+
+  let _testCallBack1 = function () {
+    //no-op
+  };
+
+  let output = jsxToString(
+    <Basic test1={_testCallBack1} test2={function() {}} />, {
+      detectFunctions: true
+    }
+  );
+
+  t.equal(output, '<Basic test1={_testCallBack1}\n  test2={function test2() {}} />');
+});
+
 test('test a react component with react children', function(t) {
   t.plan(1);
 


### PR DESCRIPTION
Small addition which I think is very useful, especially for those people who are lazy and don't want to manually override functions by using `keyValueOverride`.

It allows to get this
`<Basic test1={_testCallBack1} test2={function test2() {}} />` out of this
`<Basic test1={_testCallBack1} test2={function() {}} />` automatically.