### PR TITLE
Allow keyValueOverride to be dynamic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,8 +92,16 @@ function jsxToString (component, options) {
           component.props[key]) &&
         opts.ignoreProps.indexOf(key) === -1)
     }).map(key => {
-      let value = opts.keyValueOverride[key] ||
-        serializeItem(component.props[key], {...opts, key});
+      let value;
+
+      if (typeof opts.keyValueOverride[key] === 'function') {
+        value = opts.keyValueOverride[key](component.props[key]);
+      } else if (opts.keyValueOverride[key]) {
+        value = opts.keyValueOverride[key]
+      } else {
+        value = serializeItem(component.props[key], {...opts, key});
+      }
+
       if (typeof value !== 'string' || value[0] !== "'") {
         value = `{${value}}`;
       }

--- a/test/index.js
+++ b/test/index.js
@@ -118,6 +118,35 @@ test('test a react component with custom name function', function(t) {
   t.equal(output, '<Basic test1={_testCallBack1}\n  test2={_testCallBack2} />');
 });
 
+test('test a react component with dynamic keyValueOverride', function(t) {
+  t.plan(2);
+
+  const keyValueOverride = {
+    test1: function (propValue) {
+      if (typeof propValue === 'function') {
+        return propValue.name
+      } else {
+        return '_thisIsNotAFunction';
+      }
+    }
+  };
+
+  function testCallback() {
+    //no-op
+  };
+
+  let output1 = jsxToString(
+    <Basic test1={testCallback} />, { keyValueOverride }
+  );
+
+  let output2 = jsxToString(
+    <Basic test1={'Not a function'} />, { keyValueOverride }
+  );
+
+  t.equal(output1, '<Basic test1={testCallback} />');
+  t.equal(output2, '<Basic test1={_thisIsNotAFunction} />');
+});
+
 test('test a react component with function code enabled', function(t) {
   t.plan(1);
 


### PR DESCRIPTION
This allows keyValueOverride to be a dynamically generated string based on the value of the prop.

```jsx
jsxToString(<Test prop1={'Hello'} />, { keyValueOverride: { prop1(value) { return value + ' World'; } }});
// <Test prop1='Hello World' />
```