### PR TITLE
omit `key` key if `ignoreProps` include it as well

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,8 @@ function jsxToString (component, options) {
       }
       return `${key}=${value}`;
     }).join(`\n${indentation}`);
-    if (component.key) {
+
+    if (component.key && opts.ignoreProps.indexOf('key') === -1) {
       componentData.props += `key='${component.key}'`;
     }
 


### PR DESCRIPTION
It allows you to get rid of `key` property in output JSX if you need to.