### PR TITLE
Add option for self-closing HTML tag behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ console.log(jsxToString(<Basic test1="ignore" />, {
 })); //outputs: <CustomName />
 ```
 
+  * useSelfClosingTags (boolean)
+
+    Optional. Defaults to true. Determines whether to use self-closing HTML tags where possible in the output. For example:
+
+```js
+import jsxToString from 'jsx-to-string';
+
+console.log(jsxToString(<Basic />), { useSelfClosingTags: true }); // outputs <Basic />
+console.log(jsxToString(<Basic />), { useSelfClosingTags: false }); // outputs <Basic></Basic>
+```
+
 ### License
 
 [MIT](https://github.com/alansouzati/jsx-to-string/blob/master/LICENSE)

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,8 @@ function jsxToString (component, options) {
     ignoreProps: [],
     keyValueOverride: {},
     spacing: 0,
-    detectFunctions: false
+    detectFunctions: false,
+    useSelfClosingTags: true
   };
 
   const opts = {...baseOpts, ...options};
@@ -136,8 +137,10 @@ function jsxToString (component, options) {
     return `<${componentData.name}${componentData.props}>\n` +
       `${indentation}${componentData.children}\n` +
       `${indentation.slice(0, -2)}</${componentData.name}>`;
-  } else {
+  } else if (opts.useSelfClosingTags) {
     return `<${componentData.name}${componentData.props} />`;
+  } else {
+    return `<${componentData.name}${componentData.props}></${componentData.name}>`;
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -356,4 +356,11 @@ test('test a react component with multiple children and immutable props', functi
   );
 
   t.equal(output, '<Basic>\n  <BasicChild>\n    <BasicChild props={{"test": "abc"}}>\n      <BasicChild>\n        Title\n      </BasicChild>\n      <BasicChild>\n        Title 2\n      </BasicChild>\n    </BasicChild>\n  </BasicChild>\n</Basic>');
+
+  test('test conversion of self-closing tags to non self-closing', function(t) {
+     t.plan(1);
+
+     const output = jsxToString(<Basic />, { useSelfClosingTags: false });
+     t.equal(output, '<Basic></Basic>');
+  });
 });


### PR DESCRIPTION
This adds an option to convert input like `<Basic />`  or `<Basic></Basic>` (elements that have no children) to `<Basic></Basic>` instead of forcing it to be `<Basic />`. I've added `useSelfClosingTags` as an option, which defaults to `true` (so the current, original behavior remains the default).

I'm using this this to write views in JSX with a framework other than React, but the framework doesn't support self-closing custom tags. It seems like there are a lot of other [things to consider](http://stackoverflow.com/a/3558200/1762237) with self-closing tags, so the option might be useful to others who'd like to use the output of this package without a virtual DOM.