### PR TITLE
Add support for short boolean syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,28 @@ console.log(jsxToString(<Basic><svg /><img /><p>I am alone</p></Basic>, {
 })); //outputs: <Basic><p>I am alone</p></Basic>
 ```
 
+  * shortBooleanSyntax (boolean)
+
+  Optional. Defaults to false. Whether or not to show the short or long boolean syntax.
+
+```js
+import React from 'react';
+import jsxToString from 'jsx-to-string';
+//or var jsxToString = require('jsx-to-string');
+
+let Basic = React.createClass({
+  render() {
+    return (
+      <div />
+    );
+  }
+}); //this is your react component
+
+console.log(jsxToString(<Basic test test2={false} test3={true}>, {
+  shortBooleanSyntax: true,
+})); //outputs: <Basic test test3 />
+```
+
   * displayName (string)
 
     A custom value to be used as the component name. For example:

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ let Basic = React.createClass({
 
 console.log(jsxToString(<Basic test test2={false} test3={true}>, {
   shortBooleanSyntax: true,
-})); //outputs: <Basic test test3 />
+})); //outputs: <Basic test test2={false} test3 />
 ```
 
   * displayName (string)

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ function jsxToString (component, options) {
       } else if (opts.keyValueOverride[key]) {
         value = opts.keyValueOverride[key]
       } else if (opts.shortBooleanSyntax && typeof component.props[key] === 'boolean' && component.props[key]) {
-        if (component.props[key]) return key;
+        return key;
       } else {
         value = serializeItem(component.props[key], {...opts, key});
       }

--- a/src/index.js
+++ b/src/index.js
@@ -106,9 +106,8 @@ function jsxToString (component, options) {
         value = opts.keyValueOverride[key](component.props[key]);
       } else if (opts.keyValueOverride[key]) {
         value = opts.keyValueOverride[key]
-      } else if (opts.shortBooleanSyntax && typeof component.props[key] === 'boolean') {
+      } else if (opts.shortBooleanSyntax && typeof component.props[key] === 'boolean' && component.props[key]) {
         if (component.props[key]) return key;
-        return;
       } else {
         value = serializeItem(component.props[key], {...opts, key});
       }

--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ function jsxToString (component, options) {
         value = `{${value}}`;
       }
       return `${key}=${value}`;
-    }).filter(key => key).join(`\n${indentation}`);
+    }).join(`\n${indentation}`);
 
     if (component.key && opts.ignoreProps.indexOf('key') === -1) {
       componentData.props += `key='${component.key}'`;

--- a/src/index.js
+++ b/src/index.js
@@ -106,15 +106,17 @@ function jsxToString (component, options) {
         value = opts.keyValueOverride[key](component.props[key]);
       } else if (opts.keyValueOverride[key]) {
         value = opts.keyValueOverride[key]
+      } else if (opts.shortBooleanSyntax && typeof component.props[key] === 'boolean') {
+        if (component.props[key]) return key;
+        return;
       } else {
         value = serializeItem(component.props[key], {...opts, key});
       }
-
       if (typeof value !== 'string' || value[0] !== "'") {
         value = `{${value}}`;
       }
       return `${key}=${value}`;
-    }).join(`\n${indentation}`);
+    }).filter(key => key).join(`\n${indentation}`);
 
     if (component.key && opts.ignoreProps.indexOf('key') === -1) {
       componentData.props += `key='${component.key}'`;

--- a/test/index.js
+++ b/test/index.js
@@ -428,7 +428,7 @@ test('test a simple react component with boolean props and shortBooleanSyntax on
     }
   );
 
-  t.equal(output, '<Basic test\n  test3 />');
+  t.equal(output, '<Basic test\n  test2={false}\n  test3 />');
 });
 
 test('test a complex react component with boolean props and shortBooleanSyntax on', function(t) {
@@ -446,5 +446,5 @@ test('test a complex react component with boolean props and shortBooleanSyntax o
     }
   );
 
-  t.equal(output, '<Basic test=\'abc\'\n  test2={4}\n  test4\n  test5={{"abc": "abc"}}\n  test6=\'\'\n  test8>\n  <BasicChild test1\n    test3={5}\n    test4={6}>\n    Title 1\n  </BasicChild>\n</Basic>');
+  t.equal(output, '<Basic test=\'abc\'\n  test2={4}\n  test4\n  test5={{"abc": "abc"}}\n  test6=\'\'\n  test7={false}\n  test8>\n  <BasicChild test1\n    test2={false}\n    test3={5}\n    test4={6}>\n    Title 1\n  </BasicChild>\n</Basic>');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -417,3 +417,21 @@ test('test a deep react component with multiple ignore tags', function(t) {
 
   t.equal(output, '<Basic>\n  <p>\n    <div>\n      <p>\n        Title 2\n      </p>\n    </div>\n    <BasicChild>\n      Title 3\n    </BasicChild>\n  </p>\n</Basic>');
 });
+
+test('test a react component with boolean props and shortBooleanSyntax on', function(t) {
+  t.plan(1);
+
+  let output = jsxToString(
+    <Basic test="abc" test2={4} test4={true}
+      test5={{abc: "abc"}} test6="">
+      <BasicChild test1 test2={false} test3={5} test4={6}>
+        Title 1
+      </BasicChild>
+    </Basic>,
+    {
+      shortBooleanSyntax: true,
+    }
+  );
+
+  t.equal(output, '<Basic test=\'abc\'\n  test2={4}\n  test4\n  test5={{"abc": "abc"}}\n  test6=\'\'>\n  <BasicChild test1\n    test3={5}\n    test4={6}>\n    Title 1\n  </BasicChild>\n</Basic>');
+});

--- a/test/index.js
+++ b/test/index.js
@@ -423,7 +423,7 @@ test('test a react component with boolean props and shortBooleanSyntax on', func
 
   let output = jsxToString(
     <Basic test="abc" test2={4} test4={true}
-      test5={{abc: "abc"}} test6="">
+      test5={{abc: "abc"}} test6="" test7={false} test8>
       <BasicChild test1 test2={false} test3={5} test4={6}>
         Title 1
       </BasicChild>
@@ -433,5 +433,5 @@ test('test a react component with boolean props and shortBooleanSyntax on', func
     }
   );
 
-  t.equal(output, '<Basic test=\'abc\'\n  test2={4}\n  test4\n  test5={{"abc": "abc"}}\n  test6=\'\'>\n  <BasicChild test1\n    test3={5}\n    test4={6}>\n    Title 1\n  </BasicChild>\n</Basic>');
+  t.equal(output, '<Basic test=\'abc\'\n  test2={4}\n  test4\n  test5={{"abc": "abc"}}\n  test6=\'\'\n  test8>\n  <BasicChild test1\n    test3={5}\n    test4={6}>\n    Title 1\n  </BasicChild>\n</Basic>');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -418,7 +418,20 @@ test('test a deep react component with multiple ignore tags', function(t) {
   t.equal(output, '<Basic>\n  <p>\n    <div>\n      <p>\n        Title 2\n      </p>\n    </div>\n    <BasicChild>\n      Title 3\n    </BasicChild>\n  </p>\n</Basic>');
 });
 
-test('test a react component with boolean props and shortBooleanSyntax on', function(t) {
+test('test a simple react component with boolean props and shortBooleanSyntax on', function(t) {
+  t.plan(1);
+
+  let output = jsxToString(
+    <Basic test test2={false} test3={true}/>,
+    {
+      shortBooleanSyntax: true,
+    }
+  );
+
+  t.equal(output, '<Basic test\n  test3 />');
+});
+
+test('test a complex react component with boolean props and shortBooleanSyntax on', function(t) {
   t.plan(1);
 
   let output = jsxToString(


### PR DESCRIPTION
Hello @alansouzati 

This PR adds the short boolean syntax feature asked in issue #29 .

It is separated in three parts:

    * An example of the feature in the README
    * Two tests covering simple & more complex use case
    * The implementation of the solution in the main function

Closes #29 