### PR TITLE
Add indents to multi-line formatted object strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,11 @@ function jsxToString (component, options) {
       if (typeof value !== 'string' || value[0] !== "'") {
         value = `{${value}}`;
       }
+      // Is `value` a multi-line string?
+      const valueLines = value.split(/\r\n|\r|\n/);
+      if (valueLines.length > 1) {
+        value = valueLines.join(`\n${indentation}`);
+      }
       return `${key}=${value}`;
     }).join(`\n${indentation}`);
 

--- a/test/index.js
+++ b/test/index.js
@@ -170,7 +170,7 @@ test('test a react component with function code enabled', function(t) {
   );
 
   t.equal(
-    output, '<Basic test1={function _testCallBack1() {\n    //no-op\n  }} />'
+    output, '<Basic test1={function _testCallBack1() {\n      //no-op\n    }} />'
   );
 });
 


### PR DESCRIPTION
_Similar to #27, but based on the latest version of this library. Also, sorry about the delayed follow-up on this!_

## Description
Depending on its content, an object might be stringified as a multi-line string. I noticed this and added a bit of code to conditionally add indentation to all but the first line of the multi-string value in this case.

### Before
The `breakpoints` prop is a multi-line object, but it doesn't have the correct indentation below.
```jsx
<Responsive as={ThemedFigure}
  title='Shared Figure Title'
  breakpoints={{
"(max-width: 539px)": {
  "src": "http://placehold.it/320x160",
  "caption": "For some reason, this is just a captioned image on mobile."
},
"(min-width: 540px)": {
  "caption": "On desktop, this is a looping video. Try resizing the window to see what happens on mobile.",
  "children": <FrameAnimation src='https://video1.nytimes.com/paidpost/belvedere/the-view-from-here/tabletop.mp4' />
}
  }} />
```

### After
Now the multi-line object is correctly indented.
```jsx
<Responsive as={ThemedFigure}
  title='Shared Figure Title'
  breakpoints={{
    "(max-width: 539px)": {
      "src": "http://placehold.it/320x160",
      "caption": "For some reason, this is just a captioned image on mobile."
    },
    "(min-width: 540px)": {
      "caption": "On desktop, this is a looping video. Try resizing the window to see what happens on mobile.",
      "children": <FrameAnimation src='https://video1.nytimes.com/paidpost/belvedere/the-view-from-here/tabletop.mp4' />
    }
  }} />
```