### PR TITLE
Option to print props on a single line when component has children

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,32 @@ console.log(jsxToString(<Basic test1="ignore" />, {
 })); //outputs: <CustomName />
 ```
 
+  * singleLineProps (boolean)
+
+    Optional. Defaults to false. Prints props on a single line when the component has children.
+
+```js
+import React from 'react';
+import jsxToString from 'jsx-to-string';
+//or var jsxToString = require('jsx-to-string');
+
+let Basic = React.createClass({
+  render() {
+    return (
+      <div />
+    );
+  }
+}); //this is your react component
+
+console.log(jsxToString(<Basic test1="prop1" test2="prop2">child</Basic>, {
+  singleLineProps: true
+}));
+//outputs:
+//<Basic test1="prop1" test2="prop2">
+//  child
+//</Basic>
+```
+
 ### License
 
 [MIT](https://github.com/alansouzati/jsx-to-string/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ console.log(jsxToString(<Basic test1="prop1" test2="prop2">child</Basic>, {
   singleLineProps: true
 }));
 //outputs:
-//<Basic test1="prop1" test2="prop2">
+//<Basic test1='prop1' test2='prop2'>
 //  child
 //</Basic>
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,8 @@ function jsxToString (component, options) {
     ignoreTags: [],
     keyValueOverride: {},
     spacing: 0,
-    detectFunctions: false
+    detectFunctions: false,
+    singleLineProps: false
   };
 
   const opts = {...baseOpts, ...options};
@@ -120,7 +121,7 @@ function jsxToString (component, options) {
         value = valueLines.join(`\n${indentation}`);
       }
       return `${key}=${value}`;
-    }).join(`\n${indentation}`);
+    }).join(opts.singleLineProps ? ' ' : `\n${indentation}`);
 
     if (component.key && opts.ignoreProps.indexOf('key') === -1) {
       componentData.props += `key='${component.key}'`;


### PR DESCRIPTION
Potential solution for #40 
Adds a boolean option `singleLineProps` to make props print on a single line. Defaults to false.
Note that this solution is pretty naive. Something more robust might involve setting a max characters per line, but this works perfectly for my use case.