### PR TITLE
add support for forwardRef function naming

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,8 @@ function jsxToString (component, options) {
 
   const baseOpts = {
     displayName: component.type.displayName || component.type.name ||
+      // get the name of a forwardRef component (must be a named function - see: https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools)
+      (component.type.render && component.type.render.name) ||
       component.type,
     ignoreProps: [],
     ignoreTags: [],


### PR DESCRIPTION
Awesome package! I found an edge case where components wrapped with `forwardRef` were not displaying correctly. I tested and the following change fixes this issue, at least for _named_ functions.

https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools